### PR TITLE
add update to enable users to add themselves to the leaderboard via google form

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ The project is pure react React
 
 Node version is `v20.5.1`
 
-
 ### To run:
 
 git clone the repo
@@ -27,7 +26,6 @@ Make sure you ran `npm install` beforehand
 
 You should see the homepage which loads the leaderboard.
 
-
 ### Main Files
 
 99% of logic is `src/components/leaderboard.js`
@@ -36,13 +34,27 @@ This displays the leaderboard and imports data from a json that contains all use
 
 The JSON file is located in `public/leaderboard.json`
 
+# To Add New Users via a Google Form
+
+```
+- create a google form
+- make a question "What is your leetcode username"
+- make sure the sheet that the responses are stored in is public
+- get the link to the sheet
+- use the link in the wget command below
+
+cd query_scripts
+
+wget --no-check-certificate --output-document=users.csv '[public link to google sheet for example https://docs.google.com/spreadsheets/d/11_utLlhDXp8BGzKDW954O3l93v9ahFVOXHBavsaemBQ/]export?format=csv'
+
+python3 add_users_to_json.py
+```
+
 ## Ideas for Improvement
 
-##### People can't add themselves into the list
+##### People can't remove themselves from the list
 
-solutions -> Google Form for signing people up / removing people
-
-Twitch authentication -> Give a key/ID to each user and allow them to add and remove the user that matches their ID
+solutions -> Google Form for removing people with script that updates the JSON
 
 ##### Prediction rating should be overwritten after Wednesday for official rating
 Add a new key to the JSON for is_predicted_elo

--- a/query_scripts/add_users_to_json.py
+++ b/query_scripts/add_users_to_json.py
@@ -1,8 +1,17 @@
 import json
+import csv
 
 def read_usernames_from_file(filename):
-    with open(filename, 'r') as file:
-        return [line.strip() for line in file.readlines()]
+    usernames = []
+    column_name = 'What is your leetcode username' 
+
+    with open('users.csv', 'r', newline='') as csvfile:
+        csvreader = csv.DictReader(csvfile)
+        for row in csvreader:
+            usernames.append(row[column_name])
+    return usernames
+
+    
 
 def load_existing_users(filename):
     with open(filename, 'r') as file:
@@ -13,19 +22,20 @@ def update_json(filename, users):
         json.dump(users, file, indent=4)
 
 def add_users_to_json(usernames_file, json_file):
-    new_usernames = read_usernames_from_file(usernames_file)
+    all_usernames = read_usernames_from_file(usernames_file)
     existing_users = load_existing_users(json_file)
-    for username in new_usernames:
-        new_user = {
-            "name": username,
-            "elo": 0,
-            "prev_elo": 0,
-            "prev_problem_count": 0,
-            "current_problem_delta": 0,
-            "problems_each_week": [],
-            "current_problem_count": 0
-        }
-        existing_users.append(new_user)
+    for username in all_usernames:
+        if username not in existing_users:
+            new_user = {
+                "name": username,
+                "elo": 0,
+                "prev_elo": 0,
+                "prev_problem_count": 0,
+                "current_problem_delta": 0,
+                "problems_each_week": [],
+                "current_problem_count": 0
+            }
+            existing_users.append(new_user)
     update_json(json_file, existing_users)
 
 if __name__ == "__main__":


### PR DESCRIPTION
- enables users to add themselves via a google form. Note: you must set up the Google Form. See README
- you must run the script manually. First you must download the google form as a csv with the wget command in the README, then you must run the script
- the script adds only new usernames (don't exist in current users) from the csv to the json
- you can set this up to run on a cronjob on whatever sever you have this project deployed on so that it runs automatically, say, every day
- I tested locally and it worked
- hope this is helpful!